### PR TITLE
fix guacamole on the weekend

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,13 @@
 # Guacamole database container using MySQL
 #
 # VERSION 0.1
+ARG GUAC_VERSION=1.0.0
+FROM guacamole/guacamole:${GUAC_VERSION} as GUAC
+RUN /opt/guacamole/bin/initdb.sh --mysql > /initdb.sql
 
 FROM mysql
-
+COPY --from=GUAC /initdb.sql /docker-entrypoint-initdb.d/guac-init.sql
 # Update these to stay in line with the official guacamole containers.
-ARG GUAC_REPO=glyptodon/guacamole-client
-ARG GUAC_VERSION=0.9.12-incubating
-
-# Fetch the needed schema files from the guacamole repo and place them where the
-# container will use them when initializing the server.
-ARG BASE_URL=https://raw.githubusercontent.com/${GUAC_REPO}/${GUAC_VERSION}/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/schema/
-ADD ${BASE_URL}001-create-schema.sql /docker-entrypoint-initdb.d/
-ADD ${BASE_URL}002-create-admin-user.sql /docker-entrypoint-initdb.d/
 
 # Create a simple script that will run before the schema files and modify them
 # to use the database created by the MYSQL_DATABASE environment variable.

--- a/Dockerfile-guacamole
+++ b/Dockerfile-guacamole
@@ -1,0 +1,9 @@
+ARG GUAC_VERSION=1.0.0
+FROM guacamole/guacamole:${GUAC_VERSION}
+ARG GUAC_VERSION=1.0.0
+
+RUN mkdir -p /root/.guactemplate/extensions
+RUN curl -sL "http://apache.org/dyn/closer.cgi?action=download&filename=guacamole/${GUAC_VERSION}/binary/guacamole-auth-quickconnect-${GUAC_VERSION}.tar.gz" | tar xOzf - guacamole-auth-quickconnect-${GUAC_VERSION}/guacamole-auth-quickconnect-${GUAC_VERSION}.jar > /root/.guactemplate/extensions/guacamole-auth-quickconnect-${GUAC_VERSION}.jar
+RUN curl -sL "http://apache.org/dyn/closer.cgi?action=download&filename=guacamole/${GUAC_VERSION}/binary/guacamole-auth-totp-${GUAC_VERSION}.tar.gz" | tar xOzf - guacamole-auth-totp-${GUAC_VERSION}/guacamole-auth-totp-${GUAC_VERSION}.jar > /root/.guactemplate/extensions/guacamole-auth-totp-${GUAC_VERSION}.jar
+
+ENV GUACAMOLE_HOME=/root/.guactemplate

--- a/Dockerfile-guacd
+++ b/Dockerfile-guacd
@@ -1,0 +1,59 @@
+FROM ubuntu:bionic as build
+
+#ARG GUACD_VERSION=1.0.0
+ARG BUILD_DATE
+ARG VCS_REF
+
+ENV \
+WORKDIR /tmp
+RUN \
+  sed -i '/deb-src/s/^# //' /etc/apt/sources.list && \
+  apt update -y
+RUN apt install -y dpkg-dev build-essential curl devscripts
+RUN apt -y source libssh2 && apt -y build-dep libssh2
+RUN curl -sL https://github.com/libssh2/libssh2/releases/download/libssh2-1.9.0/libssh2-1.9.0.tar.gz | tar xvzf -
+RUN cd libssh2-1.9.0 &&\
+  tar xvJf ../libssh2_1.8.0-1.debian.tar.xz && \
+  > debian/patches/ced924b78a40126606797ef57a74066eb3b4b83f.patch && \
+  dch -v 1.9.0-1 New upstream release && \
+  dpkg-buildpackage -b --no-sign
+RUN ls -l /libssh2*deb
+
+RUN apt install -y /libssh2-1_1.9.0-1_amd64.deb /libssh2-1-dev_1.9.0-1_amd64.deb
+
+# Build guacd with the updated libssl2
+RUN apt install -y dpkg-dev build-essential curl devscripts libavcodec-dev \
+  libavutil-dev libswscale-dev libfreerdp-dev libpango1.0-dev libvncserver-dev \
+  libpulse-dev libssl-dev libvorbis-dev libwebp-dev
+RUN apt -y source guacd && \
+  apt -y build-dep guacd && \
+  curl -sL 'http://apache.org/dyn/closer.cgi?action=download&filename=guacamole/1.0.0/source/guacamole-server-1.0.0.tar.gz' | tar xvzf - && \
+  cd guacamole-server-1.0.0 && \
+  tar xvJf ../guacamole-server_0.9.9-2build1.debian.tar.xz
+RUN cd guacamole-server-1.0.0 && \
+  dch -v 1.0.0-1 New upstream release && \
+  rm -f debian/*symbols && \
+  dh_makeshlibs
+RUN cd guacamole-server-1.0.0 && \
+  dpkg-buildpackage -b --no-sign
+RUN ls -l /*deb
+
+FROM ubuntu:bionic
+COPY --from=build /*.deb /tmp/
+RUN apt update -y && apt upgrade -y
+RUN apt install -y /tmp/guacd_1.0.0-1_amd64.deb /tmp/libguac-client-rdp0_1.0.0-1_amd64.deb /tmp/libguac-client-ssh0_1.0.0-1_amd64.deb /tmp/libguac-client-vnc0_1.0.0-1_amd64.deb /tmp/libguac11_1.0.0-1_amd64.deb /tmp/libssh2-1_1.9.0-1_amd64.deb
+RUN apt -y clean && \
+  apt -y autoremove && \
+  rm -rf /var/lib/apt/lists/* && \
+  rm -rf /tmp/*
+# Build-time metadata as defined at http://label-schema.org
+LABEL org.label-schema.build-date=$BUILD_DATE \
+  org.label-schema.name="guacd" \
+  org.label-schema.description="guacd is the native server-side proxy used by the Guacamole web application." \
+  org.label-schema.vcs-ref=$VCS_REF \
+  org.label-schema.vcs-url="https://github.com/svengo/guacd" \
+  org.label-schema.vendor="Sven Gottwald" \
+  org.label-schema.version=$GUACD_VERSION \
+  org.label-schema.schema-version="1.0"
+EXPOSE 4822
+CMD [ "/usr/sbin/guacd", "-b", "0.0.0.0", "-f" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,11 +16,17 @@ services:
 
   guacd:
     hostname: guacd
-    image: guacamole/guacd:0.9.12-incubating
+    image: disconn3ct/guacd:1.0.0
     restart: always
+    build:
+      context: .
+      dockerfile: Dockerfile-guacd
 
   guacamole:
-    image: guacamole/guacamole:0.9.12-incubating
+    image: disconn3ct/guacamole:1.0.0
+    build:
+      context: .
+      dockerfile: Dockerfile-guacamole
     restart: always
     ports:
       - 8080:8080


### PR DESCRIPTION
Just a quick batch of fixes.

* Use newest libssh (1.9.0) to support semi-modern security standards
  * I honestly looked for a reasonable dist that packaged it, but no luck. Everyone stops at 1.8.0 except Fedora and.. no. If I went there, I'd have to package ffmpeg/libav and such instead. I did that once, way back in the dark ages, and I'm not ever doing it again. 😀
* Update to v1.0.0
* Fetch DB init script automatically
* Add some nifty plugins
